### PR TITLE
fix(cert-manager): disable Gateway API support

### DIFF
--- a/apps/cert-manager/base/helmrelease.yaml
+++ b/apps/cert-manager/base/helmrelease.yaml
@@ -29,4 +29,4 @@ spec:
     config:
       apiVersion: controller.config.cert-manager.io/v1alpha1
       kind: ControllerConfiguration
-      enableGatewayAPI: true
+      enableGatewayAPI: false


### PR DESCRIPTION
## Summary

- Disable `enableGatewayAPI` in the cert-manager HelmRelease values.
- The understairs cluster does not have Gateway API CRDs installed (envoy-gateway is commented out in `clusters/understairs/kustomization.yaml`), so cert-manager crash-loops at startup with `the Gateway API CRDs do not seem to be present, but ExperimentalGatewayAPISupport is set to true`.

## Test plan

- [ ] Flux reconciles the HelmRelease without error
- [ ] cert-manager pod in `cert-manager` namespace reaches Ready
- [ ] Issuers and Certificates continue to be reconciled