### PR TITLE
feat(understairs): enable envoy-gateway for Gateway API

### DIFF
--- a/clusters/understairs/cert-manager.yaml
+++ b/clusters/understairs/cert-manager.yaml
@@ -13,3 +13,5 @@ spec:
   prune: true
   wait: true
   timeout: 10m0s
+  dependsOn:
+    - name: envoy-gateway

--- a/clusters/understairs/kustomization.yaml
+++ b/clusters/understairs/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
   - tailscale-config.yaml
   - cert-manager.yaml
   - certificates.yaml
-  # - envoy-gateway.yaml
-  # - envoy-gateway-config.yaml
+  - envoy-gateway.yaml
+  - envoy-gateway-config.yaml
   - shared-secrets.yaml
   - external-secrets-operator.yaml
   - external-secrets.yaml


### PR DESCRIPTION
## Summary

- Re-enable `envoy-gateway` and `envoy-gateway-config` in `clusters/understairs/kustomization.yaml`.
- Add `dependsOn: [envoy-gateway]` to the `cert-manager` Flux Kustomization on understairs so it waits for the Gateway API CRDs before applying.

## Why

cert-manager has `enableGatewayAPI: true` but the Gateway API CRDs were not installed on understairs (envoy-gateway was commented out), so the controller crash-looped at startup with `the Gateway API CRDs do not seem to be present`. The envoy-gateway HelmRelease ships the CRDs (`crds: CreateReplace`), and the dependsOn + `wait: true` chain ensures cert-manager only reconciles once envoy-gateway is healthy.

Supersedes #45 (which disabled the cert-manager Gateway API flag instead).

## Test plan

- [ ] Flux reconciles `envoy-gateway` Kustomization successfully on understairs
- [ ] Gateway API CRDs (`gateways.gateway.networking.k8s.io`, etc.) are present
- [ ] `cert-manager` Kustomization moves past `dependsOn` and reconciles
- [ ] cert-manager pod reaches Ready without the Gateway API error
- [ ] Existing Certificates / Issuers continue to reconcile