### PR TITLE
fix: bump source.toolkit.fluxcd.io to v1

### DIFF
--- a/apps/envoy-gateway/base/helmrepository.yaml
+++ b/apps/envoy-gateway/base/helmrepository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: envoy-gateway

--- a/apps/project-contour/base/helmrepository.yaml
+++ b/apps/project-contour/base/helmrepository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: bitnami

--- a/apps/retina/base/ocirepository.yaml
+++ b/apps/retina/base/ocirepository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: retina


### PR DESCRIPTION
## Summary

- Bump `source.toolkit.fluxcd.io/v1beta2` to `v1` on the remaining HelmRepository / OCIRepository manifests.
- source-controller in the running Flux (v2.8.7) only serves `v1`, so any reconciliation referencing v1beta2 fails dry-run with `no matches for kind "HelmRepository" in version "source.toolkit.fluxcd.io/v1beta2"`.

This unblocks #46 (envoy-gateway re-enablement) so the cert-manager dependency chain can complete.

## Test plan

- [ ] `envoy-gateway` Kustomization reconciles successfully
- [ ] HelmRelease `envoy-gateway` becomes Ready and installs Gateway API CRDs
- [ ] `cert-manager` Kustomization clears the dependsOn gate and reconciles
- [ ] cert-manager pod is Ready