### PR TITLE
feat(understairs): install csi-driver-nfs for Synology NFS PVs

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -5,3 +5,4 @@ https://logs-prod-012.grafana.net/loki/api/v1/push
 https://charts.longhorn.io/
 https://github.com/kube-on-the-cheap/apps
 https://raw.githubusercontent.com/datreeio/CRDs-catalog
+https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/*

--- a/apps/csi-driver-nfs/base/helmrelease.yaml
+++ b/apps/csi-driver-nfs/base/helmrelease.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: csi-driver-nfs
+  namespace: flux-system
+spec:
+  interval: 30m
+  timeout: 10m
+  releaseName: csi-driver-nfs
+  targetNamespace: csi-driver-nfs
+  chart:
+    spec:
+      chart: csi-driver-nfs
+      version: "~4.13"
+      sourceRef:
+        kind: HelmRepository
+        name: csi-driver-nfs
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  driftDetection:
+    mode: enabled
+  valuesFrom:
+    - kind: ConfigMap
+      name: csi-driver-nfs-values

--- a/apps/csi-driver-nfs/base/helmrepository.yaml
+++ b/apps/csi-driver-nfs/base/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: csi-driver-nfs
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts

--- a/apps/csi-driver-nfs/base/kustomization.yaml
+++ b/apps/csi-driver-nfs/base/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/apps/csi-driver-nfs/base/namespace.yaml
+++ b/apps/csi-driver-nfs/base/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: csi-driver-nfs
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/apps/csi-driver-nfs/overlays/understairs/csi-driver-nfs-values.yaml
+++ b/apps/csi-driver-nfs/overlays/understairs/csi-driver-nfs-values.yaml
@@ -1,0 +1,32 @@
+---
+# Talos kubelet directory matches the chart default (/var/lib/kubelet), so no
+# override is needed there.
+#
+# Node DaemonSet tolerations are left at the chart default (operator: Exists),
+# which means the node plugin runs on both the control-plane (pi1) and worker
+# (minipc1). Apps that consume NFS-backed PVs only schedule on workers, but
+# having the plugin present on every node is harmless and matches how the
+# openebs-rawfile DaemonSet is configured on this cluster.
+#
+# Controller runs as a single replica with runOnControlPlane=false, so it
+# lands on minipc1.
+#
+# No StorageClass is created here: consumer apps (calibre-web, audiobookshelf)
+# reference static PVs that point at the Synology NFS exports directly via
+# csi.driver: nfs.csi.k8s.io. The existing openebs-rawfile StorageClass remains
+# the cluster default.
+controller:
+  replicas: 1
+  runOnControlPlane: false
+
+externalSnapshotter:
+  # Snapshot CRDs are not used by the current NFS workloads. Leave the
+  # snapshotter sidecar enabled (chart default) but skip the cluster-wide
+  # snapshot-controller deployment and CRDs to avoid clashing with any future
+  # centralised snapshot-controller install.
+  enabled: false
+  customResourceDefinitions:
+    enabled: false
+
+storageClass:
+  create: false

--- a/apps/csi-driver-nfs/overlays/understairs/kustomization.yaml
+++ b/apps/csi-driver-nfs/overlays/understairs/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+configMapGenerator:
+  - name: csi-driver-nfs-values
+    namespace: flux-system
+    files:
+      - values.yaml=csi-driver-nfs-values.yaml
+configurations:
+  - kustomizeconfig.yaml

--- a/apps/csi-driver-nfs/overlays/understairs/kustomizeconfig.yaml
+++ b/apps/csi-driver-nfs/overlays/understairs/kustomizeconfig.yaml
@@ -1,0 +1,6 @@
+---
+nameReference:
+  - kind: ConfigMap
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/clusters/understairs/csi-driver-nfs.yaml
+++ b/clusters/understairs/csi-driver-nfs.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: csi-driver-nfs
+  namespace: flux-system
+spec:
+  interval: 15m
+  sourceRef:
+    kind: GitRepository
+    name: platform
+  path: ./apps/csi-driver-nfs/overlays/understairs
+  prune: true
+  wait: true
+  timeout: 10m

--- a/clusters/understairs/kustomization.yaml
+++ b/clusters/understairs/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - cilium.yaml
   - openebs-localpv.yaml
+  - csi-driver-nfs.yaml
   - tailscale.yaml
   - tailscale-config.yaml
   - cert-manager.yaml


### PR DESCRIPTION
## Summary

- Installs the upstream Kubernetes csi-driver-nfs Helm chart (~4.13) on the understairs cluster.
- Mirrors the openebs-localpv app layout (HelmRepository + HelmRelease in base, configMapGenerator-driven values in overlay, kustomizeconfig.yaml for nameReference).
- No StorageClass provisioned: initial consumers (calibre-web, audiobookshelf in the apps repo) reference static PVs with csi.driver: nfs.csi.k8s.io directly, and creating a competing default would clash with openebs-rawfile.
- Controller runs on minipc1 (runOnControlPlane: false); node DaemonSet tolerates all taints, matching openebs-localpv.
- VolumeSnapshot controller and CRDs disabled to avoid collision with a future centralised snapshot-controller; the sidecar is left in place.

## Why

Unblocks the apps PR (kube-on-the-cheap/apps#3) which adds calibre-web and audiobookshelf, both backed by NFS exports from a Synology NAS. Those Deployments depend on this CSI driver being present so the static PVs can attach.

## Test plan

- [ ] kustomize build apps/csi-driver-nfs/overlays/understairs succeeds
- [ ] kustomize build clusters/understairs succeeds
- [ ] After merge: Flux reconciles the csi-driver-nfs Kustomization to Ready
- [ ] CSIDriver nfs.csi.k8s.io exists on the cluster
- [ ] csi-driver-nfs controller pod Running on minipc1
- [ ] csi-driver-nfs node DaemonSet pod Running on both pi1 and minipc1
- [ ] No regression to existing openebs-rawfile StorageClass or its workloads