### PR TITLE
fix(external-dns): add install/upgrade remediation retries

### DIFF
--- a/apps/external-dns/base/helmrelease.yaml
+++ b/apps/external-dns/base/helmrelease.yaml
@@ -19,8 +19,12 @@ spec:
   install:
     # createNamespace: true
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled
   valuesFrom:


### PR DESCRIPTION
## Problem

A single failed Helm install transitions the external-dns HelmRelease to ` + "`Stalled`" + ` and Flux stops retrying forever. Hit this on understairs at 2026-05-24 when transient DNS recursion issues caused image-pull / webhook stalls during install. The Deployment eventually recovered (and has been healthy with 9-day uptime) but the HelmRelease has shown red ever since.

## Fix

Add ` + "`install.remediation.retries: 3`" + ` and ` + "`upgrade.remediation.retries: 3`" + ` to the base HelmRelease so Flux self-heals from transient install/upgrade failures.

## Notes

- After merge, the currently-stalled HelmRelease will not retry on its own — the ` + "`Stalled`" + ` state is sticky. A ` + "`flux suspend && flux resume`" + ` (or equivalent annotation) is needed to kick it.
- Applies to both clusters (base change).

## Test plan

- [ ] kustomize build understairs + freeloader overlays passes (verified locally)
- [ ] After merge: HelmRelease spec carries new ` + "`remediation`" + ` blocks
- [ ] After manually kicking the stalled release: HelmRelease reconciles to Ready