### PR TITLE
chore: add HelmRelease install/upgrade remediation retries

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -6,3 +6,5 @@ https://charts.longhorn.io/
 https://github.com/kube-on-the-cheap/apps
 https://raw.githubusercontent.com/datreeio/CRDs-catalog
 https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/*
+https://github.com/stefanprodan/podinfo/blob/master/charts/podinfo/values.yaml
+https://github.com/microsoft/retina/issues/1582

--- a/apps/argo-cd/base/helmrelease.yaml
+++ b/apps/argo-cd/base/helmrelease.yaml
@@ -19,8 +19,12 @@ spec:
   install:
     # createNamespace: true
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled
   valuesFrom:

--- a/apps/cert-manager/base/helmrelease.yaml
+++ b/apps/cert-manager/base/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
         name: jetstack
   install:
     createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled
   valuesFrom:

--- a/apps/cloudnative-pg/base/helmrelease.yaml
+++ b/apps/cloudnative-pg/base/helmrelease.yaml
@@ -21,6 +21,8 @@ spec:
     crds: CreateReplace
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled
   values:

--- a/apps/csi-driver-nfs/base/helmrelease.yaml
+++ b/apps/csi-driver-nfs/base/helmrelease.yaml
@@ -18,8 +18,12 @@ spec:
         name: csi-driver-nfs
   install:
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled
   valuesFrom:

--- a/apps/envoy-gateway/base/helmrelease.yaml
+++ b/apps/envoy-gateway/base/helmrelease.yaml
@@ -19,8 +19,12 @@ spec:
   install:
     createNamespace: true
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled
   valuesFrom:

--- a/apps/external-secrets-operator/base/helmrelease.yaml
+++ b/apps/external-secrets-operator/base/helmrelease.yaml
@@ -19,7 +19,11 @@ spec:
   install:
     createNamespace: true
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled

--- a/apps/grafana/base/helmrelease.yaml
+++ b/apps/grafana/base/helmrelease.yaml
@@ -19,8 +19,12 @@ spec:
   install:
     # createNamespace: true
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled
   valuesFrom:

--- a/apps/longhorn/base/helmrelease.yaml
+++ b/apps/longhorn/base/helmrelease.yaml
@@ -20,7 +20,11 @@ spec:
   install:
     createNamespace: true
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled

--- a/apps/openebs-localpv/base/helmrelease.yaml
+++ b/apps/openebs-localpv/base/helmrelease.yaml
@@ -18,8 +18,12 @@ spec:
         name: openebs
   install:
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled
   valuesFrom:

--- a/apps/podinfo/base/helmrelease.yaml
+++ b/apps/podinfo/base/helmrelease.yaml
@@ -17,6 +17,9 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   # Default values
   # https://github.com/stefanprodan/podinfo/blob/master/charts/podinfo/values.yaml
   values:

--- a/apps/project-contour/base/helmrelease.yaml
+++ b/apps/project-contour/base/helmrelease.yaml
@@ -19,8 +19,12 @@ spec:
   install:
     createNamespace: true
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled
   valuesFrom:

--- a/apps/retina/base/helmrelease.yaml
+++ b/apps/retina/base/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
     # crds: CreateReplace
     remediation:
       retries: 2
+  upgrade:
+    remediation:
+      retries: 2
   # upgrade:
   #   crds: CreateReplace
   driftDetection:

--- a/apps/tailscale/base/helmrelease.yaml
+++ b/apps/tailscale/base/helmrelease.yaml
@@ -19,8 +19,12 @@ spec:
   install:
     # createNamespace: true
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled
   # valuesFrom:

--- a/apps/velero/base/helmrelease.yaml
+++ b/apps/velero/base/helmrelease.yaml
@@ -19,8 +19,12 @@ spec:
   install:
     # createNamespace: true
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
   driftDetection:
     mode: enabled
   valuesFrom:


### PR DESCRIPTION
## Summary

Adds `install.remediation.retries: 3` and `upgrade.remediation.retries: 3` to every base HelmRelease in this repo that lacked them, so transient install/upgrade failures self-heal instead of permanently stalling the HelmRelease.

### Files getting both blocks (11):

- argo-cd, cert-manager, csi-driver-nfs, envoy-gateway, external-secrets-operator, grafana, longhorn, openebs-localpv, project-contour, tailscale, velero

### Files getting only `upgrade.remediation` added (3, they already had `install.remediation`):

- cloudnative-pg (retries: 3, matching existing install value)
- podinfo (retries: 3, matching existing install value)
- retina (retries: 2, matching its existing install value of 2)

### Files NOT modified:

- external-dns — both blocks added in PR #50

## Why

We've seen this pattern bite three times now: external-dns (DNS recursion at install), paperless-ngx (upgrade overran timeout by 3s), and at-large risk for every other release. With remediation, Flux retries up to 3 times before giving up, which is enough to ride out common transient causes (slow image pulls, DNS hiccups, just-barely-over-timeout completions).

Companion apps-repo PR: kube-on-the-cheap/apps#7

## Secondary change

Adds two specific GitHub comment-URLs to `.lycheeignore` (podinfo values.yaml link and retina issue link). Both are stable public references already in the file as comments; lychee returns 400 (Cloudflare bot-blocking) at pre-push time. Same documented pattern as the existing fluxcd.io/artifacthub.io ignores.

## Test plan

- [ ] kustomize build for all 14 affected overlays passes (verified locally by implementer agent)
- [ ] After merge: no behavioural change unless a HelmRelease install/upgrade fails — in which case Flux will retry up to 3 (or 2 for retina) times instead of stalling